### PR TITLE
增加ModLoaderGui 的行为。现在会尝试通过 boot.json 注册的Addon信息，来下载缺失的依赖

### DIFF
--- a/src/DependencyDownloadAddonParams.ts
+++ b/src/DependencyDownloadAddonParams.ts
@@ -7,13 +7,7 @@ export interface downloadDir
 }
 
 
-/*
-"Dependence" 和 "Dependency" 都与依赖关系有关，但在特定上下文中，它们有所不同。一般情况下，"Dependence" 更多地表达的是 "依赖" 这一动态关系，而 "Dependency" 的含义则更偏向于 "依赖项" 这种静态的存在。
-在软件开发领域，当我们说 "Dependency" 时，更多的是指项目的外部依赖。例如，在一个 JavaScript 项目中，你可能会有许多 npm packages 作为你的 "Dependencies"。在这个场景下，"Dependency" 是具体的库或者模块，它是一个静态的存在。
-此外，"Dependency" 也常常用于描述对象之间的关系，在面向对象的编程中，一个对象依赖于另一个对象，我们通常称这种关系为 "Dependency"。
-然而，“Dependence”通常用于描述抽象的、非具体物质的依赖关系，例如“他对咖啡有依赖性”（He has a dependence on coffee）。
-请注意，这些只是大体规则的说明，不同的人可能在实际语境中根据习惯用法或行业标准稍作调整使用这两个词汇。在具体语境中，最好还是遵循实际使用的约定或标准。
- */
+
 /**
  *
  * Represents the parameters required for downloading dependencies.

--- a/src/DependencyDownloadAddonParams.ts
+++ b/src/DependencyDownloadAddonParams.ts
@@ -23,9 +23,9 @@ export function checkdownloadDirObject(c: any) : c is downloadDir {
         ;
 }
 
-export function checkAddrObject(c: any) : c is DependencyDownloadParams {
+export function checkAddrArray(c: any) : c is downloadDir[] {
     return isObject(c)
-        && isArray(get(c, 'addr')) && every(get(c, 'addr'), checkdownloadDirObject);
+        && isArray(c) && every(c, checkdownloadDirObject);
 }
 
 

--- a/src/DependencyDownloadAddonParams.ts
+++ b/src/DependencyDownloadAddonParams.ts
@@ -1,0 +1,37 @@
+import {get, isString, isArray, every, isObject} from 'lodash';
+
+export interface downloadDir
+{
+    modName: string;
+    downloadDir: string;
+}
+
+
+/*
+"Dependence" 和 "Dependency" 都与依赖关系有关，但在特定上下文中，它们有所不同。一般情况下，"Dependence" 更多地表达的是 "依赖" 这一动态关系，而 "Dependency" 的含义则更偏向于 "依赖项" 这种静态的存在。
+在软件开发领域，当我们说 "Dependency" 时，更多的是指项目的外部依赖。例如，在一个 JavaScript 项目中，你可能会有许多 npm packages 作为你的 "Dependencies"。在这个场景下，"Dependency" 是具体的库或者模块，它是一个静态的存在。
+此外，"Dependency" 也常常用于描述对象之间的关系，在面向对象的编程中，一个对象依赖于另一个对象，我们通常称这种关系为 "Dependency"。
+然而，“Dependence”通常用于描述抽象的、非具体物质的依赖关系，例如“他对咖啡有依赖性”（He has a dependence on coffee）。
+请注意，这些只是大体规则的说明，不同的人可能在实际语境中根据习惯用法或行业标准稍作调整使用这两个词汇。在具体语境中，最好还是遵循实际使用的约定或标准。
+ */
+/**
+ *
+ * Represents the parameters required for downloading dependencies.
+ */
+export interface DependencyDownloadParams {
+    addr: downloadDir[];
+}
+
+export function checkdownloadDirObject(c: any) : c is downloadDir {
+    return isObject(c)
+        && isString(get(c, 'modName'))
+        && isString(get(c, 'downloadDir'))
+        ;
+}
+
+export function checkAddrObject(c: any) : c is DependencyDownloadParams {
+    return isObject(c)
+        && isArray(get(c, 'addr')) && every(get(c, 'addr'), checkdownloadDirObject);
+}
+
+

--- a/src/DependencyHelper.ts
+++ b/src/DependencyHelper.ts
@@ -1,0 +1,169 @@
+
+import type {SC2DataManager} from "../../../dist-BeforeSC2/SC2DataManager";
+import type {ModUtils} from "../../../dist-BeforeSC2/Utils";
+import type {ModBootJson, ModBootJsonAddonPlugin} from "../../../dist-BeforeSC2/ModLoader";
+import type {LogWrapper} from '../../../dist-BeforeSC2/ModLoadController';
+import type {ModOrderItem} from '../../../dist-BeforeSC2/ModOrderContainer';
+import {checkAddrObject, downloadDir} from "./DependencyDownloadAddonParams";
+
+
+
+export class DependencyHelper
+{
+    logger: LogWrapper;
+
+    downloadAddressMap: Map<string, downloadDir[]>;
+    installedModMap: Map<string, ModBootJson>;
+    isInProgress: boolean;
+    unresolvedMods: string[];
+    downloadedMods: string[];
+
+
+    constructor(
+        public gSC2DataManager: SC2DataManager,
+        public gModUtils: ModUtils
+    ) {
+        this.logger = gModUtils.getLogger();
+        this.downloadAddressMap = new Map();
+        this.installedModMap = new Map();
+        this.isInProgress = false;
+        this.unresolvedMods = [];
+        this.downloadedMods = [];
+
+        this.InitDownloadAddressMap(gSC2DataManager.getModLoader().getModCacheArray());
+    }
+
+
+    /**
+     * 加载新的Mod，这个接口主要是用于注册已存在的Mod，不会进行依赖的分析
+     * @param bootJson 待加载的 mod 的 bootJson
+     * @constructor
+     */
+    public AddMod(bootJson: ModBootJson): boolean {
+        let downloadDirList: downloadDir[] = [];
+        const pp = bootJson.addonPlugin?.find((T: ModBootJsonAddonPlugin) => {
+            return T.addonName === 'DependenceDownloadAddon';
+        })?.params;
+        if (!checkAddrObject(pp)) {
+            console.error('[DependencyHelper] AddMod() ParamsInvalid', [bootJson.name, pp]);
+            this.logger.error(`[DependencyHelper] AddMod() ParamsInvalid: addon[${bootJson.name}]`);
+            return false;
+        }
+        this.downloadAddressMap.set(bootJson.name, downloadDirList);
+        this.installedModMap.set(bootJson.name, bootJson);
+        return true;
+    }
+
+    /**
+     * 从Dependency信息中移除指定的 Mod，这个操作并不会将其依赖也一并删除。同理，当某个 Mod 依赖它的场合，也不会把那个 Mod 删除。
+     * @param modName 待删除的 Mod 名
+     * @constructor
+     */
+    public RemoveMod(modName: string) {
+        if (!this.downloadAddressMap.has(modName)) {
+            console.error('[DependencyHelper] RemoveMod() ModNotExists', modName);
+            this.logger.error(`[DependencyHelper] RemoveMod() ModNotExists: ${modName}`);
+            return false;
+        }
+
+        this.downloadAddressMap.delete(modName);
+        this.installedModMap.delete(modName);
+
+        return true;
+    }
+
+
+    /**
+     * 检查特定 mod 的依赖情况（非semver）
+     * @param modJson 待检查的 mod
+     * @returns 没有满足的依赖 Mod 列表
+     */
+    checkDependency(modJson: ModBootJson): string[]{
+        let unresolvedMods: string[] = [];
+        if (modJson.dependenceInfo) {
+            for (const dep of modJson.dependenceInfo) {
+                if (!this.installedModMap.has(dep.modName))
+                {
+                    unresolvedMods.push(dep.modName);
+                }
+            }
+        }
+        return unresolvedMods;
+    }
+
+    /**
+     * 增加某个Mod，并试图处理其依赖项
+     * 即便有依赖项尚未被处理，这个 Mod 依然会被加入进去。
+     * @param {ModBootJson} modJson - 要增加的 Mod
+     * @param {function} downloadModCallback - 一个异步回调，用于下载、安装特定的 Mod 并再次调用这个函数。
+     *
+     * @returns {Promise<string[]>} - 返回没有被成功处理的依赖项
+     */
+    public async AddModAndResolveDependency(modJson: ModBootJson,
+                                            downloadModCallback: (param: string) => Promise<void>) : Promise<string[]>{
+        let isOuterCaller: boolean = false;
+        if (!this.isInProgress)
+        {
+            //这个方法预计应当是在一个非并行的环境下进行运行的。
+            //考虑到安装Mod可能会引入新的依赖，于是这里使用一个总的列表，来表示整个过程中没有解决的依赖。
+            this.isInProgress = true;
+            this.unresolvedMods.length = 0;
+            this.downloadedMods.length = 0;
+            isOuterCaller = true;
+        }
+        this.AddMod(modJson);
+
+        const unresolvedMods = this.checkDependency(modJson);
+        if (unresolvedMods.length > 0) {
+            for (const modName of unresolvedMods) {
+                let downloadDir: string = "";
+                try {
+                    //此处允许失败
+                    let found: boolean = false;
+                    for (const value of this.downloadAddressMap.values()) {
+                        for(const item of value)
+                        {
+                            if (item.modName === modName)
+                            {
+                                found = true;
+                                downloadDir = item.downloadDir;
+                            }
+                        }
+                        if (found)
+                            break;
+                    }
+                    if (found) {
+                        await downloadModCallback(downloadDir);
+                    }
+                } catch (error) {
+                    console.error('[DependencyHelper] AddModAndResolveDependency() Failed to download mod:', [error, downloadDir]);
+                }
+            }
+        }
+        //在安装完成后重新检查依赖，如果没有未解决的依赖，则视为安装完毕。
+        const resolveFailMods = this.checkDependency(modJson);
+        if (resolveFailMods.length > 0)
+        {
+            for (const element of resolveFailMods)
+            {
+                unresolvedMods.push(element);
+            }
+        }
+        if (isOuterCaller)
+        {
+            this.isInProgress = false;
+        }
+        else
+        {
+            this.downloadedMods.push(modJson.name);
+        }
+        return unresolvedMods;
+    }
+
+    InitDownloadAddressMap(arr: ModOrderItem[]) {
+        for (let item of arr) {
+            let json = item.mod.bootJson;
+            this.AddMod(json);
+        }
+    }
+}

--- a/src/Gui.ts
+++ b/src/Gui.ts
@@ -258,7 +258,7 @@ export class Gui {
                         try {
                             const R = await this.loadAndAddMod((vv as any));
                             // this.gui!.fields['AddMod_R'].value = `Success. reload page to take effect`;
-                            this.gui!.fields['AddMod_R'].value = `Success. 刷新页面后生效`;
+                            this.gui!.fields['AddMod_R'].value = R;
                             this.gui!.fields['AddMod_R'].reload();
                             // console.log('this.gModUtils.getModLoadController().listModLocalStorage()', this.gModUtils.getModLoadController().listModLocalStorage());
                             // const MyConfig_field_NowSideLoadModeList_r = doc.querySelector('#MyConfig_field_NowSideLoadModeList_r');
@@ -669,11 +669,11 @@ export class Gui {
         if (!window.dependencyHelper){
             window.dependencyHelper = new DependencyHelper(window.modSC2DataManager, window.modUtils);
         }
-        let unresolvedDependencies =
-            await window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl);
-        if (unresolvedDependencies.length > 0)
+        let result =
+            await window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl.bind(this));
+        if (result.unresolved.length > 0)
         {
-            this.logger.log(`loaded mod ${zipFile.name}, unresolved dependencies: ${unresolvedDependencies.join(',')}`);
+            this.logger.log(`loaded mod ${zipFile.name}, unresolved dependencies: ${result.unresolved.join(',')}`);
         }
     }
 
@@ -717,15 +717,19 @@ export class Gui {
                     if (!window.dependencyHelper){
                         window.dependencyHelper = new DependencyHelper(window.modSC2DataManager, window.modUtils);
                     }
-                    let unresolvedDependency = await
-                        window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl);
-                    if (unresolvedDependency.length > 0)
+                    let result = await
+                        window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl.bind(this));
+                    if (result.unresolved.length > 0)
                     {
-                        return `Success. Reload the page to take effect, but some dependent mods have not yet been met:${unresolvedDependency.join(',')}`;
+                        return `Success. Reload the page to take effect, but some dependent mods have not yet been met:${result.unresolved.join(',')}, installed dependencies:${result.installed.join(',')}`;
+                    }
+                    else if(result.installed.length > 0)
+                    {
+                        return `Success. Reload the page to take effect, installed dependencies:${result.installed.join(',')}`;
                     }
                 }
             }
-            return `Success. reload page to take effect`;
+            return `Success. 刷新页面后生效`;
         } catch (E: any) {
             console.error('loadAndAddMod', E);
             const m = E?.message || E?.toString() || E;

--- a/src/Gui.ts
+++ b/src/Gui.ts
@@ -1,4 +1,4 @@
-import {GM_config, Field, InitOptionsNoCustom, GM_configStruct, BootstrapBtnType} from './GM_config_TS/gm_config';
+import {BootstrapBtnType, GM_config, GM_configStruct} from './GM_config_TS/gm_config';
 import inlineGMCss from './GM.css?inlineText';
 import inlineBootstrap from 'bootstrap/dist/css/bootstrap.css?inlineText';
 
@@ -6,13 +6,14 @@ import type {SC2DataManager} from "../../../dist-BeforeSC2/SC2DataManager";
 import type {ModUtils} from "../../../dist-BeforeSC2/Utils";
 import type {ModBootJson} from "../../../dist-BeforeSC2/ModLoader";
 import type {LogWrapper} from '../../../dist-BeforeSC2/ModLoadController';
-import {isString, isSafeInteger, isNil, isArray, isEqual, cloneDeep} from "lodash";
+import {isArray, isNil, isString} from "lodash";
 import moment from "moment";
 import {LoadingProgress} from "./LoadingProgress";
 import {PassageTracer} from "./PassageTracer";
 import {DebugExport} from "./DebugExport";
 import {getStringTable, StringTableType} from './GUI_StringTable/StringTable';
 import {ModLoadSwitch} from "./ModLoadSwitch";
+import {DependencyHelper} from "./DependencyHelper";
 
 const btnType: BootstrapBtnType = 'secondary';
 
@@ -328,6 +329,9 @@ export class Gui {
                             return;
                         }
                         await this.gModUtils.getModLoadController().removeModIndexDB(vv);
+                        if (window.dependencyHelper){
+                            window.dependencyHelper.RemoveMod(vv);
+                        }
                         const MyConfig_field_RemoveMod_s = doc.querySelector('#MyConfig_field_RemoveMod_s');
 
                         const l = await this.listSideLoadMod();
@@ -636,6 +640,43 @@ export class Gui {
 
     startBanner?: HTMLDivElement;
 
+    static async fetchAndEncode(url: string): Promise<string> {
+        const response = await fetch(url);
+        const arrayBuffer = await response.arrayBuffer();
+        const bytes = new Uint8Array(arrayBuffer);
+        const binary = bytes.reduce((acc, byte) => acc + String.fromCharCode(byte), "");
+        return window.btoa(binary);
+    }
+
+    async loadAndAddModFromUrl(downloadDir: string): Promise<void> {
+        const content = await Gui.fetchAndEncode(downloadDir);
+        const zipFile: ModBootJson | string =
+            await this.gModUtils.getModLoadController().checkModZipFileIndexDB(content);
+        if (isString(zipFile)) {
+            return Promise.reject(`Error: ${zipFile}`);
+        } else {
+            try {
+                await this.gModUtils.getModLoadController().addModIndexDB(zipFile.name, content);
+            } catch (e) {
+                console.error(e);
+                try {
+                    this.gModUtils.getModLoadController().addModLocalStorage(zipFile.name, content);
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+        if (!window.dependencyHelper){
+            window.dependencyHelper = new DependencyHelper(window.modSC2DataManager, window.modUtils);
+        }
+        let unresolvedDependencies =
+            await window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl);
+        if (unresolvedDependencies.length > 0)
+        {
+            this.logger.log(`loaded mod ${zipFile.name}, unresolved dependencies: ${unresolvedDependencies.join(',')}`);
+        }
+    }
+
     async loadAndAddMod(htmlFile: HTMLInputElement) {
         try {
             const f = htmlFile.files;
@@ -671,6 +712,16 @@ export class Gui {
                         } catch (e) {
                             console.error(e);
                         }
+                    }
+                    //tryResolveDependency
+                    if (!window.dependencyHelper){
+                        window.dependencyHelper = new DependencyHelper(window.modSC2DataManager, window.modUtils);
+                    }
+                    let unresolvedDependency = await
+                        window.dependencyHelper.AddModAndResolveDependency(zipFile, this.loadAndAddModFromUrl);
+                    if (unresolvedDependency.length > 0)
+                    {
+                        return `Success. Reload the page to take effect, but some dependent mods have not yet been met:${unresolvedDependency.join(',')}`;
                     }
                 }
             }

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,6 +5,7 @@ import {PassageTracer} from "./PassageTracer";
 
 window.modLoaderGui_LoadingProgress = new LoadingProgress(window.modSC2DataManager, window.modUtils);
 window.modLoaderGui_PassageTracer = new PassageTracer(window);
+//window.dependencyHelper 要求在所有 mod 加载完毕之后才初始化，所以不在这里进行初始化
 window.modLoaderGui = new Gui(
     window.modSC2DataManager,
     window.modUtils,

--- a/src/winDef.d.ts
+++ b/src/winDef.d.ts
@@ -1,6 +1,7 @@
 import type {SC2DataManager} from "../../../dist-BeforeSC2/SC2DataManager";
 import type {ModUtils} from "../../../dist-BeforeSC2/Utils";
 import type jQuery from "jquery/misc";
+import {DependencyHelper} from "./DependencyHelper";
 
 declare global {
     interface Window {
@@ -10,6 +11,7 @@ declare global {
         modLoaderGui: Gui;
         modLoaderGui_LoadingProgress: LoadingProgress;
         modLoaderGui_PassageTracer: PassageTracer;
+        dependencyHelper: DependencyHelper;
 
         jQuery: jQuery;
     }

--- a/test/depCheck/boot.json
+++ b/test/depCheck/boot.json
@@ -1,0 +1,63 @@
+{
+  "name": "DepModA",
+  "version": "1.2.0",
+  "styleFileList": [
+  ],
+  "scriptFileList_earlyload": [
+  ],
+  "scriptFileList_inject_early": [
+  ],
+  "scriptFileList_preload": [
+  ],
+  "scriptFileList": [
+  ],
+  "tweeFileList": [
+  ],
+  "imgFileList": [
+  ],
+  "additionFile": [
+  ],
+  "addonPlugin": [
+
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "addonName": "ImageLoaderAddon",
+      "modVersion": ">=1.0.0",
+      "params": [
+      ]
+    },
+    {
+      "modName": "DependenceDownloadAddon",
+      "addonName": "DependenceDownloadAddon",
+      "modVersion": "1.0.0",
+      "params": [
+        {
+          "modName": "DepModB",
+          "downloadDir": "https://magicalastrogy.site/DepModB1.mod.zip"
+        }
+      ]
+    }
+  ],
+  "dependenceInfo": [
+    {
+      "modName": "ModLoader",
+      "version": ">=1.1.0"
+    },
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "TweeReplacer",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "ReplacePatcher",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "DepModB",
+      "version": ">=1.0.0"
+    }
+  ]
+}

--- a/test/depCheck/boot2.json
+++ b/test/depCheck/boot2.json
@@ -1,0 +1,63 @@
+{
+  "name": "DepModB",
+  "version": "1.2.0",
+  "styleFileList": [
+  ],
+  "scriptFileList_earlyload": [
+  ],
+  "scriptFileList_inject_early": [
+  ],
+  "scriptFileList_preload": [
+  ],
+  "scriptFileList": [
+  ],
+  "tweeFileList": [
+  ],
+  "imgFileList": [
+  ],
+  "additionFile": [
+  ],
+  "addonPlugin": [
+
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "addonName": "ImageLoaderAddon",
+      "modVersion": ">=1.0.0",
+      "params": [
+      ]
+    },
+    {
+      "modName": "DependenceDownloadAddon",
+      "addonName": "DependenceDownloadAddon",
+      "modVersion": "1.0.0",
+      "params": [
+        {
+          "modName": "DepModC",
+          "downloadDir": "https://magicalastrogy.site/DepModC.mod.zip"
+        }
+      ]
+    }
+  ],
+  "dependenceInfo": [
+    {
+      "modName": "ModLoader",
+      "version": ">=1.1.0"
+    },
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "TweeReplacer",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "ReplacePatcher",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "DepModC",
+      "version": ">=1.0.0"
+    }
+  ]
+}

--- a/test/depCheck/boot3.json
+++ b/test/depCheck/boot3.json
@@ -1,0 +1,48 @@
+{
+  "name": "DepModC",
+  "version": "1.2.0",
+  "styleFileList": [
+  ],
+  "scriptFileList_earlyload": [
+  ],
+  "scriptFileList_inject_early": [
+  ],
+  "scriptFileList_preload": [
+  ],
+  "scriptFileList": [
+  ],
+  "tweeFileList": [
+  ],
+  "imgFileList": [
+  ],
+  "additionFile": [
+  ],
+  "addonPlugin": [
+
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "addonName": "ImageLoaderAddon",
+      "modVersion": ">=1.0.0",
+      "params": [
+      ]
+    }
+  ],
+  "dependenceInfo": [
+    {
+      "modName": "ModLoader",
+      "version": ">=1.1.0"
+    },
+    {
+      "modName": "ModLoader DoL ImageLoaderHook",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "TweeReplacer",
+      "version": ">=1.0.0"
+    },
+    {
+      "modName": "ReplacePatcher",
+      "version": ">=1.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
原本的 PR：https://github.com/Lyoko-Jeremie/sugarcube-2-ModLoader/pull/4

经过讨论移动到 ModLoaderGui 中进行实现

新增的 Addon 使用例：
```json
    {
      "modName": "DependenceDownloadAddon",
      "addonName": "DependenceDownloadAddon",
      "modVersion": "1.0.0",
      "params": [
        {
          "modName": "DepModB",
          "downloadDir": "https://magicalastrogy.site/DepModB1.mod.zip"
        }
      ]
    }
```